### PR TITLE
Update README for macOS port note

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ npx nodemon index.js
 
 This runs the Express server on port `5000` by default.
 
+On macOS the default port 5000 may already be in use, so you can start the backend on another port with:
+
+```bash
+PORT=5001 npx nodemon index.js
+```
+
 ## Starting the Frontend
 
 From the frontend directory:


### PR DESCRIPTION
## Summary
- document how to run backend on another port when macOS already uses port 5000
- reference running nodemon with `npx`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684519a60134832691e3ff14946639d0